### PR TITLE
Use table from settings when rolling action and description

### DIFF
--- a/src/logic/mgme-core-2e.js
+++ b/src/logic/mgme-core-2e.js
@@ -48,11 +48,11 @@ export default class MGMECore2e {
     }
 
     static mgmeActions() {
-        MGMEOracleUtils._mgmeMultipleTableOracle([{name: "Mythic GME: Action 1 (2e)"}, {name: "Mythic GME: Action 2 (2e)"}], "Action Meaning");
+        MGMEOracleUtils._mgmeMultipleTableOracle([{name: MGMECommon._mgmeFindValueBySetting('actionTable')}, {name: MGMECommon._mgmeFindValueBySetting('subjectTable')}], "Action Meaning");
     }
 
     static mgmeDescriptions() {
-        MGMEOracleUtils._mgmeMultipleTableOracle([{name: "Mythic GME: Description 1 (2e)"}, {name: "Mythic GME: Description 2 (2e)"}], "Description Meaning");
+        MGMEOracleUtils._mgmeMultipleTableOracle([{name: MGMECommon._mgmeFindValueBySetting('descriptionsAdvTable')}, {name: MGMECommon._mgmeFindValueBySetting('descriptionsAdjTable')}], "Description Meaning");
     }
 
     static mgmeSceneAdjust() {

--- a/src/utils/mgme-common.js
+++ b/src/utils/mgme-common.js
@@ -96,6 +96,10 @@ export default class MGMECommon {
       return undefined
   }
 
+  static _mgmeFindValueBySetting(setting) {
+    return game.settings.get('mythic-gme-tools', setting);
+  }
+
 }
 
 


### PR DESCRIPTION
Do not know if this was intended.
When using the oracle roll, the action table was used, that was configured in the settings, but when you use the Action/Description buttons, it was not using the settings.