### PR TITLE
Fix MGME Show button crash by replacing _render with render API

### DIFF
--- a/src/logic/mgme-cards.js
+++ b/src/logic/mgme-cards.js
@@ -75,7 +75,8 @@ export default class MGMECards {
               editable: false,
               shareable: true
             });
-            ip._render(true, {title: "Card", height: parseInt(height), width: parseInt(height) / 1.5}).then(() => ip.shareImage());
+            ip.render(true, {title: "Card", height: parseInt(height), width: parseInt(height) / 1.5});
+            queueMicrotask(() => ip.shareImage());
           }
         },
         chat: {


### PR DESCRIPTION
On foundry v13 I get an error when clicking show card in the flow in the `MGMECards` class

- Changed the call to `ip._render` to `ip.render`, and moved the `ip.shareImage()` invocation into a `queueMicrotask` to ensure it runs after rendering is complete.